### PR TITLE
Speed up test execution

### DIFF
--- a/src/main/resources/activiti.cfg.xml
+++ b/src/main/resources/activiti.cfg.xml
@@ -23,6 +23,7 @@
 		<property name="databaseSchemaUpdate" value="true" />
 		<property name="jobExecutorActivate" value="true" />
 		<property name="mailSessionJndi" value="Session"/>
+		<property name="createDiagramOnDeploy" value="false"/>
 	</bean>
 
 	<bean id="processEngine" class="org.activiti.spring.ProcessEngineFactoryBean">


### PR DESCRIPTION
Generating the diagram accounts for >50% of execution time